### PR TITLE
requires guzzlehttp/guzzle ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": ">= 8.0",
-    "guzzlehttp/guzzle": "^7.3",
+    "guzzlehttp/guzzle": "^7.3.0",
     "symfony/serializer": "5.2.*",
     "symfony/property-access": "5.2.*",
     "ext-json": "*",


### PR DESCRIPTION
josalba/packlink 0.0.3 requires guzzlehttp/guzzle ^7.3 -> found guzzlehttp/guzzle[7.3.0, ..., 7.5.0] but these were not loaded, likely because it conflicts with another require.